### PR TITLE
Right-align labels

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@
   .labels {
     padding-right: 16px;
     width: 50%;
+    text-align: right;
   }
 
   .inputs {


### PR DESCRIPTION
Use `text-align: right;` to fix the alignment. IMO, `align-self: flex-end;` is a bit of an overkill.

## Before
![chrome_GPXGZty8mk](https://user-images.githubusercontent.com/5093058/56413671-ce887800-62ba-11e9-9197-9917ca07f9f0.png)

## After
![chrome_27oqBB0WEO](https://user-images.githubusercontent.com/5093058/56413670-ce887800-62ba-11e9-9737-56a8f06b580c.png)
